### PR TITLE
Optimize bundle and add lazy weekly chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "vite": "^5.2.0",
-    "@vitejs/plugin-react": "^4.2.0"
+    "@vitejs/plugin-react": "^4.2.0",
+    "rollup-plugin-visualizer": "^5.12.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, lazy, Suspense } from "react";
+import { Sun, Moon } from "lucide-react";
 import "./style.css";
 import { todayKey, todayIdx, hhmmToMin, WEEK_LABELS } from "./utils/date";
 import { REWARDS, randomLoot, STAGE_THRESHOLDS } from "./gamification/rewards";
-import LevelMap from "./components/LevelMap";
-import RewardCard from "./components/RewardCard";
 import Mascota from "./components/Mascota";
 import Walker from "./components/Walker";
 import { getJSON, setJSON } from "./utils/storage";
+
+const LevelMap = lazy(() => import("./components/LevelMap"));
+const RewardCard = lazy(() => import("./components/RewardCard"));
+const WeeklyChart = lazy(() => import("./components/WeeklyChart"));
 
 /** ----- Config base ----- */
 const ALL_MEALS = [
@@ -93,6 +96,8 @@ function App() {
     const arr = getJSON("weeklyData", [0,0,0,0,0,0,0]);
     return Array.isArray(arr) && arr.length === 7 ? arr : [0,0,0,0,0,0,0];
   });
+
+  const [showChart, setShowChart] = useState(false);
 
   /** Inventario y recompensas */
   const [inventory, setInventory] = useState(() => getJSON("inventory", []));
@@ -223,7 +228,9 @@ function App() {
       <header className="header">
         <h1>🌱 Progreso Nutricional</h1>
         <div className="header-actions">
-          <button className="ghost" aria-label="Cambiar tema" onClick={() => setDark(d=>!d)}>{dark ? "☀️ Claro" : "🌙 Oscuro"}</button>
+          <button className="ghost" aria-label="Cambiar tema" onClick={() => setDark(d=>!d)}>
+            {dark ? <Sun size={16} /> : <Moon size={16} />} {dark ? "Claro" : "Oscuro"}
+          </button>
           <button className="ghost" aria-label="Alternar modo Pro" onClick={() => setProMode(v=>!v)}>{proMode ? "🔓 Pro" : "🔒 Pro"}</button>
         </div>
       </header>
@@ -356,14 +363,18 @@ function App() {
       {/* MAPA DE NIVELES */}
       <div className="card">
         <h2>🗺️ Mapa de niveles (1–21)</h2>
-        <LevelMap streak={streak} thresholds={STAGE_THRESHOLDS}/>
+        <Suspense fallback={<div className="muted">Cargando…</div>}>
+          <LevelMap streak={streak} thresholds={STAGE_THRESHOLDS} />
+        </Suspense>
       </div>
 
       {/* RECOMPENSA DEL DÍA */}
       {todaysReward && (
         <div className="card">
           <h2>🎁 Recompensa por hito</h2>
-          <RewardCard reward={todaysReward} claimed={rewardClaimed} onClaim={claimReward}/>
+          <Suspense fallback={<div className="muted">Cargando…</div>}>
+            <RewardCard reward={todaysReward} claimed={rewardClaimed} onClaim={claimReward} />
+          </Suspense>
         </div>
       )}
 
@@ -385,15 +396,26 @@ function App() {
       {/* HISTORIAL SEMANAL */}
       <div className="card">
         <h2>📅 Historial semanal</h2>
-        <div className="levelmap">
-          {weeklyData.map((val,i)=>(
-            <div key={i} className="lm-cell done" style={{height:60}}>
-              <div className="lm-num">{WEEK_LABELS[i]}</div>
-              <div className="muted">{val}%</div>
+        <button className="link" onClick={() => setShowChart(s => !s)} aria-label="Ver gráfico">
+          {showChart ? "Ver tabla" : "Ver gráfico"}
+        </button>
+        {showChart ? (
+          <Suspense fallback={<div className="muted">Cargando…</div>}>
+            <WeeklyChart data={weeklyData} />
+          </Suspense>
+        ) : (
+          <>
+            <div className="levelmap">
+              {weeklyData.map((val, i) => (
+                <div key={i} className="lm-cell done" style={{ height: 60 }}>
+                  <div className="lm-num">{WEEK_LABELS[i]}</div>
+                  <div className="muted">{val}%</div>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-        <div className="muted" style={{marginTop:8}}>Verde ≥60%, ámbar &lt;60%.</div>
+            <div className="muted" style={{ marginTop: 8 }}>Verde ≥60%, ámbar &lt;60%.</div>
+          </>
+        )}
       </div>
 
       {/* TIP DEL DÍA */}
@@ -404,16 +426,4 @@ function App() {
     </div>
   );
 }
-codex/fix-multiple-export-errors-in-app.jsx
-
-codex/fix-build-errors-in-app.jsx
-
-codex/fix-app.jsx-export-issues-for-vercel-deployment
 export default App;
-
- codex/fix-vite-build-and-prepare-for-vercel-deploy
-
- main
-
- main
- main

--- a/src/components/Mascota.jsx
+++ b/src/components/Mascota.jsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { streakToStageKey } from "../gamification/rewards";
-import { SPRITES } from "../gamification/spriteAssets";
+
+const useBadges = import.meta.env.VITE_USE_BADGES_INSTEAD_OF_SPRITES === "true";
 
 /**
  * Mascota animada mediante spritesheet de 4 frames horizontales.
@@ -10,10 +11,25 @@ import { SPRITES } from "../gamification/spriteAssets";
  *  - speed: duración de la animación en segundos
  */
 export default function Mascota({ streak = 0, size = 128, speed = 1, className = "" }) {
+  const [sprites, setSprites] = useState(null);
+
+  useEffect(() => {
+    if (!useBadges) {
+      import("../gamification/spriteAssets").then((m) => setSprites(m.SPRITES));
+    }
+  }, []);
+
   const sheet = useMemo(() => {
+    if (useBadges || !sprites) return null;
     const key = streakToStageKey(streak);
-    return SPRITES[key] || SPRITES.base;
-  }, [streak]);
+    return sprites[key] || sprites.base;
+  }, [streak, sprites]);
+
+  if (useBadges) {
+    return <div className={`mascota-badge ${className}`} aria-label="mascota">🐻</div>;
+  }
+
+  if (!sheet) return null;
 
   const style = {
     "--size": `${size}px`,

--- a/src/components/WeeklyChart.jsx
+++ b/src/components/WeeklyChart.jsx
@@ -1,0 +1,17 @@
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { WEEK_LABELS } from '../utils/date';
+
+export default function WeeklyChart({ data = [] }) {
+  const chartData = data.map((v, i) => ({ name: WEEK_LABELS[i], value: v }));
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={chartData}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="name" />
+        <YAxis />
+        <Tooltip />
+        <Bar dataKey="value" fill="#16a34a" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -4,6 +4,7 @@ export const todayIdx  = () => new Date().getDay();
 export const WEEK_LABELS = ["D", "L", "M", "M", "J", "V", "S"];
 
 export const hhmmToMin = (t) => {
-  const [h, m] = t.split(":").map(Number);
+  const [h, m] = String(t).split(":").map(Number);
+  if (Number.isNaN(h) || Number.isNaN(m)) return 0;
   return h * 60 + m;
 };

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -2,6 +2,10 @@
 // Helpers to persist JSON data safely in localStorage.
 
 export function getJSON(key, fallback) {
+  if (typeof key !== 'string') {
+    console.warn('getJSON: key must be a string');
+    return fallback;
+  }
   try {
     const raw = localStorage.getItem(key);
     return raw ? JSON.parse(raw) : fallback;
@@ -12,6 +16,10 @@ export function getJSON(key, fallback) {
 }
 
 export function setJSON(key, value) {
+  if (typeof key !== 'string') {
+    console.warn('setJSON: key must be a string');
+    return;
+  }
   try {
     localStorage.setItem(key, JSON.stringify(value));
   } catch (err) {

--- a/vercel.json
+++ b/vercel.json
@@ -1,14 +1,10 @@
 {
   "builds": [
-codex/fix-app.jsx-export-issues-for-vercel-deployment
     {
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": { "distDir": "dist" }
     }
-
-    { "src": "package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
- main
   ],
   "routes": [
     { "src": "/(.*)", "dest": "/index.html" }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,12 @@
 
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-})
+export default defineConfig(async () => {
+  const plugins = [react()];
+  if (process.env.ANALYZE === '1') {
+    const { visualizer } = await import('rollup-plugin-visualizer');
+    plugins.push(visualizer({ open: true }));
+  }
+  return { plugins };
+});


### PR DESCRIPTION
## Summary
- lazily load heavy UI components and chart, improving initial bundle
- add optional bundle visualizer and tighten utility helpers
- clean Vercel config and support sprite-less mascot mode

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2ab36e88323bc8a5990d7399d25