### PR TITLE
Fix Vercel routes to serve static assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
     }
   ],
   "routes": [
+    { "handle": "filesystem" },
     { "src": "/(.*)", "dest": "/index.html" }
   ]
 }


### PR DESCRIPTION
## Summary
- add filesystem handler in vercel routes so assets load correctly before SPA fallback

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3f54c28488323bb61d7c03bb3f1a2